### PR TITLE
Fixes qemu build error. Since 1.5 qemu defaults to gtk. Since then, the ...

### DIFF
--- a/source-builder/config/qemu-1-1.cfg
+++ b/source-builder/config/qemu-1-1.cfg
@@ -73,5 +73,6 @@ BuildRoot: %{_tmppath}/%{name}-root-%(%{__id_u} -n)
   %{__rmdir} $SB_BUILD_ROOT
 
   cd ${build_dir}
+  %{_ld_library_path}=$SYSROOT/lib \
   %{__make} DESTDIR=$SB_BUILD_ROOT install
   cd ${build_top}


### PR DESCRIPTION
make install triggers the use of xgettext and msgmerge to do translations.  This calls the recently compiled version of gettext, which is unable to find its library without passing LD_LIBRARY_PATH to make install.

If there's a better way to handle this (or you think this should be split off into a different qemu cfg file), let me know.
